### PR TITLE
support typescript methods and arrow funcs

### DIFF
--- a/after/queries/typescript/highlights.scm
+++ b/after/queries/typescript/highlights.scm
@@ -4,8 +4,15 @@
 (interface_declaration
   name: (type_identifier) @AlabasterDefinition)
 
+(method_definition
+  name: (property_identifier) @AlabasterDefinition)
+
 (function_declaration
   name: (identifier) @AlabasterDefinition)
+
+(variable_declarator
+  name: (identifier) @AlabasterDefinition
+  value: (arrow_function))
 
 (type_alias_declaration
   name: (type_identifier) @AlabasterDefinition)


### PR DESCRIPTION
as the title says, add @AlabasterDefinition to typescript methods and arrow functions.

example:
![image](https://github.com/user-attachments/assets/8318ad59-9dc4-443a-a356-918f313b1918)
