### PR TITLE
improved typescript highlighting

### DIFF
--- a/after/queries/typescript/highlights.scm
+++ b/after/queries/typescript/highlights.scm
@@ -17,4 +17,23 @@
 (type_alias_declaration
   name: (type_identifier) @AlabasterDefinition)
 
+;; class declarations
+(class_declaration
+  name: (type_identifier) @AlabasterDefinition)
+
+;; decorators
+(decorator
+  ((identifier) @AlabasterDefinition)?
+  (call_expression
+    function: (identifier) @AlabasterDefinition)?)
+
+;; method calls 
+(call_expression
+  function: (member_expression 
+    property: (property_identifier) @AlabasterDefinition))
+
+;; type arguments
+(type_arguments
+  (_) @AlabasterDefinition)
+
 (undefined) @AlabasterConstant


### PR DESCRIPTION
Modified the TypeScript highlighting to make it more similar to the original theme:
- Class declarations
- Decorators
- Method calls
- Type arguments
![image](https://github.com/user-attachments/assets/0de19f24-47c2-4a0c-94b9-b422456e3bad)
