### PR TITLE
Fix keyword operator highlighting

### DIFF
--- a/colors/alabaster.lua
+++ b/colors/alabaster.lua
@@ -248,6 +248,7 @@ if vim.o.background == "dark" then
         ["@function.macro"] = { fg = ansi.white },
         ["@keyword"] = { fg = ansi.white },
         ["@keyword.function"] = { fg = ansi.white },
+        ["@keyword.operator"] = { fg = punct_fg },
         ["@label"] = { fg = ansi.white },
         ["@method"] = { fg = ansi.white },
         ["@module"] = { fg = ansi.white },


### PR DESCRIPTION
Before

<img width="1886" height="418" alt="image" src="https://github.com/user-attachments/assets/ebeaf344-7b52-4509-ab5b-b8cdaf832536" />


After

<img width="709" height="195" alt="image" src="https://github.com/user-attachments/assets/8cd8ab4f-a946-408e-9ab6-215c2cd26d64" />


left - sublime text
right - neovim
