### PR TITLE
Fix color for python builtin decorators

### DIFF
--- a/after/queries/python/highlights.scm
+++ b/after/queries/python/highlights.scm
@@ -8,3 +8,6 @@
 
 ((module . (comment) @AlabasterHashbang)
  (#match? @AlabasterHashbang "^#!/"))
+
+(decorator
+  (identifier) @AlabasterBase)

--- a/colors/alabaster.lua
+++ b/colors/alabaster.lua
@@ -276,6 +276,7 @@ if vim.o.background == "dark" then
         ["@text.warning"] = { bg = "#d0d058", fg = bg },
 
         --- Theme specific
+        ["@AlabasterBase"] = { fg = ansi.white },
         ["@AlabasterConstant"] = { fg = const_fg },
         ["@AlabasterDefinition"] = { fg = def_fg },
         ["@AlabasterPunct"] = { fg = punct_fg },


### PR DESCRIPTION
python `@property` should be white as others decorators. Left side is a fix

<img width="1665" height="438" alt="image" src="https://github.com/user-attachments/assets/7a102c04-26bb-4fea-b1d4-43b6952e77c1" />


