### PR TITLE
Adding query for scala highlights

### DIFF
--- a/after/queries/scala/highlights.scm
+++ b/after/queries/scala/highlights.scm
@@ -1,0 +1,20 @@
+; vim: ft=query
+;; extends
+
+(package_clause
+  (package_identifier) @AlabasterDefinition)
+
+(function_definition
+  name: (identifier) @AlabasterDefinition)
+
+(function_declaration
+  name: (identifier) @AlabasterDefinition)
+
+(class_definition
+  name: (identifier) @AlabasterDefinition)
+
+(object_definition
+  name: (identifier) @AlabasterDefinition)
+
+(trait_definition
+  name: (identifier) @AlabasterDefinition)


### PR DESCRIPTION
## Description

Adding query  for scala highlights that adhere to [these rules](https://github.com/tonsky/sublime-scheme-alabaster#motivation)

## Screenshot

_***Note*** &mdash; I disable the comment highlights in my config_

<img width="978" height="655" alt="scala-alabaster-highlights" src="https://github.com/user-attachments/assets/da18442d-5957-4850-a1bf-0448ced2281a" />


## Example code

```scala
// single-line comment
/*
  multi-line comment
*/
package example.app
// Global object
object HighlightTest {
  val Pi: Double = 3.14159
  val Greeting: String = "Hello, Alabaster!"
  val IsScalaFun: Boolean = true
  val blah = 1 < 2
  var y = "hello"


  def add(x: Int, y: Int): Int = {
    x + y
  }
  def main(args: Array[String]): Unit = {
    println(Greeting)
  }
}
class User(val name: String, val age: Int) {
  def greet(): Unit = {
    println(s"Hello, my name is $name and I am $age years old.")
  }
}
trait Greetable {
  def greet(): Unit
}

```