### PR TITLE
Add ruby syntax

### DIFF
--- a/after/queries/ruby/highlights.scm
+++ b/after/queries/ruby/highlights.scm
@@ -1,0 +1,19 @@
+;; vim: ft=query
+;; extends
+
+;; methods
+(method
+  name: (identifier) @AlabasterDefinition)
+
+;; simple classes
+(class
+  name: (constant) @AlabasterDefinition)
+
+;; modules
+(module
+  name: (constant) @AlabasterDefinition)
+
+((simple_symbol) @AlabasterConstant)
+((hash_key_symbol) @AlabasterConstant)
+
+((instance_variable) @AlabasterPunct)

--- a/after/queries/ruby/highlights.scm
+++ b/after/queries/ruby/highlights.scm
@@ -5,6 +5,10 @@
 (method
   name: (identifier) @AlabasterDefinition)
 
+;; singleton methods (def self.method)
+(singleton_method
+  name: (identifier) @AlabasterDefinition)
+
 ;; simple classes
 (class
   name: (constant) @AlabasterDefinition)
@@ -12,6 +16,12 @@
 ;; modules
 (module
   name: (constant) @AlabasterDefinition)
+
+;; all constants in scope_resolution chains (handles any nesting depth)
+(scope_resolution
+  name: (constant) @AlabasterDefinition)
+(scope_resolution
+  scope: (constant) @AlabasterDefinition)
 
 ((simple_symbol) @AlabasterConstant)
 ((hash_key_symbol) @AlabasterConstant)


### PR DESCRIPTION
<img width="1170" height="744" alt="image" src="https://github.com/user-attachments/assets/72518de1-1265-454f-bbee-942bf255f2e1" />

Added ruby syntax, but there are some issues: 
 - could not find solution, how to highlight compact style definitions (line 9)
- only `@` symbol in instance variables like `@abc` should be highlighted