### PR TITLE
Add support for mini.nvim

### DIFF
--- a/colors/alabaster.lua
+++ b/colors/alabaster.lua
@@ -296,6 +296,8 @@ if vim.o.background == "dark" then
         TelescopeResultsTitle = { fg = ansi.yellow },
         --- fzf-lua
         FzfLuaBorder = { fg = "#2b3d40" },
+        --- mini.nvim
+        MiniPickMatchCurrent  = { fg = "#f09942" },
         --- Neogit
         NeogitPopupActionDisabled = { fg = darker_fg },
         NeogitPopupActionKey = { fg = ansi.magenta },


### PR DESCRIPTION
HIghlight matched item

before: <img width="988" height="599" alt="Screenshot 2025-10-17 at 12 30 43" src="https://github.com/user-attachments/assets/9ae99b66-1ef7-4766-ba93-4420b2a57571" />

after: 
<img width="966" height="596" alt="Screenshot 2025-10-17 at 12 31 09" src="https://github.com/user-attachments/assets/0508c771-ca7f-442f-acff-dc94b1abf59f" />
