### PR TITLE
fix c_sharp highlights

### DIFF
--- a/after/queries/c_sharp/highlights.scm
+++ b/after/queries/c_sharp/highlights.scm
@@ -1,15 +1,7 @@
 ;; vim: ft=query
 ;; extends
 
-(class_declaration
-  name: (identifier) @AlabasterDefinition)
-(struct_declaration
-  name: (identifier) @AlabasterDefinition)
-(interface_declaration
-  name: (identifier) @AlabasterDefinition)
-(record_declaration
-  name: (identifier) @AlabasterDefinition)
-(record_struct_declaration
+(type_declaration
   name: (identifier) @AlabasterDefinition)
 (constructor_declaration
   name: (identifier) @AlabasterDefinition)
@@ -18,8 +10,6 @@
 (method_declaration
   name: (identifier) @AlabasterDefinition)
 (property_declaration
-  name: (identifier) @AlabasterDefinition)
-(enum_declaration
   name: (identifier) @AlabasterDefinition)
 (namespace_declaration
   name: (identifier) @AlabasterDefinition)


### PR DESCRIPTION
Fixes outdated c_sharp highlights configuration mentioned in https://github.com/p00f/alabaster.nvim/issues/15.