### PR TITLE
Proper Kotlin Support

### DIFF
--- a/after/queries/kotlin/highlights.scm
+++ b/after/queries/kotlin/highlights.scm
@@ -9,4 +9,16 @@
 (object_declaration
   (type_identifier) @AlabasterDefinition)
 
+(string_literal) @AlabasterString
+
+(boolean_literal) @AlabasterConstant
+(integer_literal) @AlabasterConstant
+(long_literal) @AlabasterConstant
+(unsigned_literal) @AlabasterConstant
+(real_literal) @AlabasterConstant
+
+(line_comment) @AlabasterHashbang
+(multiline_comment) @Comment
+
+
 (modifiers (annotation (user_type (type_identifier) @AlabasterPunctuation)))


### PR DESCRIPTION
Amazing theme! But only works for classes and interfaces in Kotlin. They made a different node type for object declaration, so I am fixing that. Screenshots demonstrate the problem:

object AuthRouting – is not highlighted even though it's a definition

<img width="1710" height="1107" alt="Screenshot 2025-10-21 at 12 32 26" src="https://github.com/user-attachments/assets/cc36c721-4e17-4e8a-99c3-106cc50bd0b9" />

class is highlighted 

<img width="1710" height="1107" alt="Screenshot 2025-10-21 at 12 32 33" src="https://github.com/user-attachments/assets/7b9a2df5-b368-4b4a-a513-ef246219b267" />
