### PR TITLE
Fix treesitter highlight for zig and hare

### DIFF
--- a/after/queries/hare/highlights.scm
+++ b/after/queries/hare/highlights.scm
@@ -2,8 +2,7 @@
 ;; extends
 
 (function_declaration
-  name: (identifier
-          (name) @AlabasterDefinition))
+  name: (identifier) @AlabasterDefinition)
 
 (type_declaration
-  (type_bindings (identifier (name) @AlabasterDefinition)))
+  (identifier) @AlabasterDefinition)

--- a/after/queries/zig/highlights.scm
+++ b/after/queries/zig/highlights.scm
@@ -1,10 +1,5 @@
 ;; vim: ft=query
 ;; extends
 
-(Decl
-  (VarDecl
-    variable_type_function: (IDENTIFIER) @AlabasterDefinition
-    (ErrorUnionExpr)))
-
-(FnProto
-  function: (IDENTIFIER) @AlabasterDefinition)
+(function_declaration
+  name: (identifier) @AlabasterDefinition)


### PR DESCRIPTION
This fixes the treesitter problem, although lsp highlight will override it...

---

ps: I noticed that this repo on sourcehut is not synchronized with GitHub. Should we use the version on GitHub or the one on sourcehut?