### PR TITLE
fix(c_sharp): use individual fields instead of `type_declaration`

### DIFF
--- a/after/queries/c_sharp/highlights.scm
+++ b/after/queries/c_sharp/highlights.scm
@@ -1,15 +1,38 @@
-;; vim: ft=query
-;; extends
+; vim: ft=query
+; extends
 
-(type_declaration
+(class_declaration
   name: (identifier) @AlabasterDefinition)
-(constructor_declaration
+
+(struct_declaration
   name: (identifier) @AlabasterDefinition)
-(destructor_declaration
+
+(enum_declaration
   name: (identifier) @AlabasterDefinition)
+
+(interface_declaration
+  name: (identifier) @AlabasterDefinition)
+
+(delegate_declaration
+  name: (identifier) @AlabasterDefinition)
+
+(record_declaration
+  name: (identifier) @AlabasterDefinition)
+
 (method_declaration
   name: (identifier) @AlabasterDefinition)
+
+(constructor_declaration
+  name: (identifier) @AlabasterDefinition)
+
+(destructor_declaration
+  name: (identifier) @AlabasterDefinition)
+
+(method_declaration
+  name: (identifier) @AlabasterDefinition)
+
 (property_declaration
   name: (identifier) @AlabasterDefinition)
+
 (namespace_declaration
   name: (identifier) @AlabasterDefinition)


### PR DESCRIPTION
Based on #35, it looks like nvim-treesitter on neovim 0.12.1 stopped supporting the `type_declaration`.

I removed that and added all other fields individually.